### PR TITLE
Trailing comma lead to parsing error in the package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "id": "cordova-plugin-template",
     "platforms": [
       "android",
-      "ios",
+      "ios"
     ]
   },
   "description": "A starting point for a Cordova Plugin"


### PR DESCRIPTION
A trailing comma at the end of the platforms array lead to failure to parse error when adding the plugin to a cordova or ionic project. I just removed the comma and it adds successfully.